### PR TITLE
Remove extra `process` method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,4 @@ const prettify = postcss.plugin('postcss-prettify', () => css => {
   if (css.first && css.first.raws) css.first.raws.before = ''
 })
 
-prettify.process = css => postcss([prettify]).process(css)
-
 export default prettify


### PR DESCRIPTION
`postcss.plugin` [defines](https://github.com/postcss/postcss/blob/master/lib/postcss.es6#L125) `process` method on a plugin on its own, so this one is extra.
